### PR TITLE
Add Polaris RBAC resources

### DIFF
--- a/docs/data-sources/polaris_catalog_role.md
+++ b/docs/data-sources/polaris_catalog_role.md
@@ -1,0 +1,31 @@
+---
+page_title: "iceberg_polaris_catalog_role Data Source - Iceberg"
+subcategory: ""
+description: |-
+  Look up a Polaris catalog role by name and catalog.
+---
+
+# iceberg_polaris_catalog_role (Data Source)
+
+Look up a Polaris catalog role by name and catalog.
+
+## Example Usage
+
+```terraform
+data "iceberg_polaris_catalog_role" "existing" {
+  catalog_name = "my_catalog"
+  name         = "table_reader"
+}
+```
+
+## Schema
+
+### Required
+
+- `catalog_name` (String) The catalog containing the role.
+- `name` (String) The name of the catalog role.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+- `properties` (Map of String) Arbitrary metadata properties for the catalog role.

--- a/docs/data-sources/polaris_principal_role.md
+++ b/docs/data-sources/polaris_principal_role.md
@@ -1,0 +1,30 @@
+---
+page_title: "iceberg_polaris_principal_role Data Source - Iceberg"
+subcategory: ""
+description: |-
+  Look up a Polaris principal role by name.
+---
+
+# iceberg_polaris_principal_role (Data Source)
+
+Look up a Polaris principal role by name.
+
+## Example Usage
+
+```terraform
+data "iceberg_polaris_principal_role" "existing" {
+  name = "admin"
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) The name of the principal role.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+- `federated` (Bool) Whether the role is managed by an external identity provider.
+- `properties` (Map of String) Arbitrary metadata properties for the principal role.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,12 +30,19 @@ Use Terraform to interact with Iceberg REST Catalog instances.
 ## Data Sources
 
 - [iceberg_table](data-sources/table.md) — Read metadata for an existing table from the catalog.
+- [iceberg_polaris_principal_role](data-sources/polaris_principal_role.md) — Look up a Polaris principal role by name.
+- [iceberg_polaris_catalog_role](data-sources/polaris_catalog_role.md) — Look up a Polaris catalog role by name and catalog.
 
 ## Resources
 
 - [iceberg_namespace](resources/namespace.md) — Manage a catalog namespace.
 - [iceberg_table](resources/table.md) — Manage an Iceberg table.
 - [iceberg_polaris_principal](resources/polaris_principal.md) — Manage a Polaris principal (Polaris deployments).
+- [iceberg_polaris_principal_role](resources/polaris_principal_role.md) — Manage a Polaris principal role.
+- [iceberg_polaris_principal_role_assignment](resources/polaris_principal_role_assignment.md) — Assign a principal role to a Polaris principal.
+- [iceberg_polaris_catalog_role](resources/polaris_catalog_role.md) — Manage a Polaris catalog role.
+- [iceberg_polaris_catalog_role_assignment](resources/polaris_catalog_role_assignment.md) — Assign a catalog role to a principal role.
+- [iceberg_polaris_grant](resources/polaris_grant.md) — Grant a privilege on a securable object to a catalog role.
 
 ## Schema
 

--- a/docs/resources/polaris_catalog_role.md
+++ b/docs/resources/polaris_catalog_role.md
@@ -1,0 +1,42 @@
+---
+page_title: "iceberg_polaris_catalog_role Resource - Iceberg"
+subcategory: ""
+description: |-
+  A resource for managing Polaris catalog roles.
+---
+
+# iceberg_polaris_catalog_role (Resource)
+
+A resource for managing Polaris catalog roles.
+
+## Example Usage
+
+```terraform
+resource "iceberg_polaris_catalog_role" "namespace_admin" {
+  catalog_name = "my_catalog"
+  name         = "namespace_admin"
+}
+```
+
+## Schema
+
+### Required
+
+- `catalog_name` (String) The catalog this role belongs to.
+- `name` (String) The name of the catalog role.
+
+### Optional
+
+- `properties` (Map of String) Arbitrary metadata properties for the catalog role.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import iceberg_polaris_catalog_role.example catalog_name/role_name
+```

--- a/docs/resources/polaris_catalog_role_assignment.md
+++ b/docs/resources/polaris_catalog_role_assignment.md
@@ -1,0 +1,41 @@
+---
+page_title: "iceberg_polaris_catalog_role_assignment Resource - Iceberg"
+subcategory: ""
+description: |-
+  Assigns a catalog role to a principal role.
+---
+
+# iceberg_polaris_catalog_role_assignment (Resource)
+
+Assigns a catalog role to a principal role, granting the catalog role's
+privileges to all principals in the principal role.
+
+## Example Usage
+
+```terraform
+resource "iceberg_polaris_catalog_role_assignment" "assignment" {
+  principal_role_name = iceberg_polaris_principal_role.data_engineer.name
+  catalog_name        = "my_catalog"
+  catalog_role_name   = iceberg_polaris_catalog_role.namespace_admin.name
+}
+```
+
+## Schema
+
+### Required
+
+- `principal_role_name` (String) The principal role receiving the assignment.
+- `catalog_name` (String) The catalog containing the role to assign.
+- `catalog_role_name` (String) The catalog role to assign.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import iceberg_polaris_catalog_role_assignment.example principal_role/catalog/catalog_role
+```

--- a/docs/resources/polaris_grant.md
+++ b/docs/resources/polaris_grant.md
@@ -1,0 +1,60 @@
+---
+page_title: "iceberg_polaris_grant Resource - Iceberg"
+subcategory: ""
+description: |-
+  Grants a privilege on a securable object to a catalog role.
+---
+
+# iceberg_polaris_grant (Resource)
+
+Grants a privilege on a securable object to a catalog role.
+
+## Example Usage
+
+```terraform
+# Grant on a namespace
+resource "iceberg_polaris_grant" "namespace_read" {
+  catalog_name      = "my_catalog"
+  catalog_role_name = iceberg_polaris_catalog_role.namespace_admin.name
+  privilege         = "NAMESPACE_LIST"
+  namespace         = ["my_namespace"]
+}
+
+# Grant on the entire catalog
+resource "iceberg_polaris_grant" "catalog_admin" {
+  catalog_name      = "my_catalog"
+  catalog_role_name = iceberg_polaris_catalog_role.admin.name
+  privilege         = "CATALOG_MANAGE_CONTENT"
+  catalog           = "my_catalog"
+}
+```
+
+## Schema
+
+### Required
+
+- `catalog_name` (String) The catalog containing the role.
+- `catalog_role_name` (String) The catalog role receiving the grant.
+- `privilege` (String) The privilege to grant.
+
+### Optional
+
+- `catalog` (String) Grant on the whole catalog. Mutually exclusive with namespace/table/view.
+- `namespace` (List of String) Namespace to grant on. Required if table or view is set.
+- `table` (String) Table name to grant on. Requires namespace.
+- `view` (String) View name to grant on. Requires namespace.
+- `cascade` (Bool) Cascade revocation to subresources (only used on destroy).
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import iceberg_polaris_grant.example catalog_name/role_name/CATALOG/null/CATALOG_MANAGE_CONTENT
+terraform import iceberg_polaris_grant.example catalog_name/role_name/NAMESPACE/my_namespace/NAMESPACE_LIST
+terraform import iceberg_polaris_grant.example catalog_name/role_name/TABLE/my_namespace.my_table/TABLE_READ_DATA
+```

--- a/docs/resources/polaris_principal_role.md
+++ b/docs/resources/polaris_principal_role.md
@@ -1,0 +1,44 @@
+---
+page_title: "iceberg_polaris_principal_role Resource - Iceberg"
+subcategory: ""
+description: |-
+  A resource for managing Polaris principal roles.
+---
+
+# iceberg_polaris_principal_role (Resource)
+
+A resource for managing Polaris principal roles.
+
+## Example Usage
+
+```terraform
+resource "iceberg_polaris_principal_role" "data_engineer" {
+  name = "data_engineer"
+  properties = {
+    department = "engineering"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) The name of the principal role.
+
+### Optional
+
+- `federated` (Bool) Whether the role is managed by an external identity provider. Immutable after creation.
+- `properties` (Map of String) Arbitrary metadata properties for the principal role.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import iceberg_polaris_principal_role.example my_role_name
+```

--- a/docs/resources/polaris_principal_role_assignment.md
+++ b/docs/resources/polaris_principal_role_assignment.md
@@ -1,0 +1,38 @@
+---
+page_title: "iceberg_polaris_principal_role_assignment Resource - Iceberg"
+subcategory: ""
+description: |-
+  Assigns a principal role to a Polaris principal.
+---
+
+# iceberg_polaris_principal_role_assignment (Resource)
+
+Assigns a principal role to a Polaris principal.
+
+## Example Usage
+
+```terraform
+resource "iceberg_polaris_principal_role_assignment" "assignment" {
+  principal_name      = iceberg_polaris_principal.my_principal.name
+  principal_role_name = iceberg_polaris_principal_role.data_engineer.name
+}
+```
+
+## Schema
+
+### Required
+
+- `principal_name` (String) The name of the principal to assign the role to.
+- `principal_role_name` (String) The name of the principal role to assign.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import iceberg_polaris_principal_role_assignment.example principal_name/role_name
+```

--- a/internal/provider/data_source_polaris_catalog_role.go
+++ b/internal/provider/data_source_polaris_catalog_role.go
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &polarisCatalogRoleDataSource{}
+
+func NewPolarisCatalogRoleDataSource() datasource.DataSource {
+	return &polarisCatalogRoleDataSource{}
+}
+
+type polarisCatalogRoleDataSource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisCatalogRoleDataSourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	CatalogName types.String `tfsdk:"catalog_name"`
+	Name        types.String `tfsdk:"name"`
+	Properties  types.Map    `tfsdk:"properties"`
+}
+
+func (d *polarisCatalogRoleDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_catalog_role"
+}
+
+func (d *polarisCatalogRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Look up a Polaris catalog role by name and catalog.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"catalog_name": schema.StringAttribute{
+				Description: "The catalog containing the role.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the catalog role.",
+				Required:    true,
+			},
+			"properties": schema.MapAttribute{
+				Description: "Arbitrary metadata properties for the catalog role.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *polarisCatalogRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			"Expected *icebergProvider, got a different type.",
+		)
+
+		return
+	}
+	d.provider = provider
+}
+
+func (d *polarisCatalogRoleDataSource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if d.managementClient != nil {
+		return
+	}
+	if d.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := d.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	d.managementClient = client
+}
+
+func (d *polarisCatalogRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	d.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	role, err := d.managementClient.GetCatalogRole(ctx, data.CatalogName.ValueString(), data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read catalog role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(data.CatalogName.ValueString() + "/" + role.Name)
+	data.Name = types.StringValue(role.Name)
+	if len(role.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, role.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_polaris_catalog_role_test.go
+++ b/internal/provider/data_source_polaris_catalog_role_test.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const testDSRoleName = "test-ds-catalog-role"
+
+func TestAccPolarisCatalogRoleDataSource_Basic(t *testing.T) {
+	catalogURI := os.Getenv("POLARIS_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("POLARIS_CATALOG_URI not set, skipping real-cluster test")
+	}
+	managementURI := os.Getenv("POLARIS_MANAGEMENT_URI")
+	if managementURI == "" {
+		managementURI = catalogURI + "/api/management/v1"
+	}
+	token := os.Getenv("POLARIS_TOKEN")
+
+	providerCfg := testAccPolarisProviderConfigWithToken(catalogURI, managementURI, token)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + `
+resource "iceberg_polaris_catalog_role" "test" {
+  catalog_name = "` + testCatalogName + `"
+  name         = "` + testDSRoleName + `"
+}
+
+data "iceberg_polaris_catalog_role" "test" {
+  catalog_name = iceberg_polaris_catalog_role.test.catalog_name
+  name         = iceberg_polaris_catalog_role.test.name
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.iceberg_polaris_catalog_role.test", "name", testDSRoleName),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_polaris_principal_role.go
+++ b/internal/provider/data_source_polaris_principal_role.go
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &polarisPrincipalRoleDataSource{}
+
+func NewPolarisPrincipalRoleDataSource() datasource.DataSource {
+	return &polarisPrincipalRoleDataSource{}
+}
+
+type polarisPrincipalRoleDataSource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisPrincipalRoleDataSourceModel struct {
+	ID         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Federated  types.Bool   `tfsdk:"federated"`
+	Properties types.Map    `tfsdk:"properties"`
+}
+
+func (d *polarisPrincipalRoleDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_principal_role"
+}
+
+func (d *polarisPrincipalRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Look up a Polaris principal role by name.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the principal role.",
+				Required:    true,
+			},
+			"federated": schema.BoolAttribute{
+				Description: "Whether the role is managed by an external identity provider.",
+				Computed:    true,
+			},
+			"properties": schema.MapAttribute{
+				Description: "Arbitrary metadata properties for the principal role.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *polarisPrincipalRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			"Expected *icebergProvider, got a different type.",
+		)
+
+		return
+	}
+	d.provider = provider
+}
+
+func (d *polarisPrincipalRoleDataSource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if d.managementClient != nil {
+		return
+	}
+	if d.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := d.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	d.managementClient = client
+}
+
+func (d *polarisPrincipalRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	d.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	role, err := d.managementClient.GetPrincipalRole(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(role.Name)
+	data.Name = types.StringValue(role.Name)
+	data.Federated = types.BoolValue(role.Federated)
+	if len(role.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, role.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/polaris_management_client.go
+++ b/internal/provider/polaris_management_client.go
@@ -195,3 +195,223 @@ func (c *polarisManagementClient) UpdatePrincipal(ctx context.Context, name stri
 func (c *polarisManagementClient) DeletePrincipal(ctx context.Context, name string) error {
 	return c.do(ctx, http.MethodDelete, "/principals/"+url.PathEscape(name), nil, nil, nil)
 }
+
+// ─── Principal Roles ──────────────────────────────────────────────────────
+
+type polarisPrincipalRole struct {
+	Name                string            `json:"name"`
+	Federated           bool              `json:"federated,omitempty"`
+	Properties          map[string]string `json:"properties,omitempty"`
+	EntityVersion       int64             `json:"entityVersion,omitempty"`
+	CreateTimestamp     int64             `json:"createTimestamp,omitempty"`
+	LastUpdateTimestamp int64             `json:"lastUpdateTimestamp,omitempty"`
+}
+
+type polarisCreatePrincipalRoleRequest struct {
+	PrincipalRole polarisPrincipalRole `json:"principalRole"`
+}
+
+type polarisUpdatePrincipalRoleRequest struct {
+	CurrentEntityVersion int64             `json:"currentEntityVersion"`
+	Properties           map[string]string `json:"properties,omitempty"`
+}
+
+type polarisPrincipalRoles struct {
+	Roles []polarisPrincipalRole `json:"roles"`
+}
+
+func (c *polarisManagementClient) CreatePrincipalRole(ctx context.Context, req polarisCreatePrincipalRoleRequest) (*polarisPrincipalRole, error) {
+	var out polarisPrincipalRole
+	if err := c.do(ctx, http.MethodPost, "/principal-roles", nil, req, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) GetPrincipalRole(ctx context.Context, name string) (*polarisPrincipalRole, error) {
+	var out polarisPrincipalRole
+	if err := c.do(ctx, http.MethodGet, "/principal-roles/"+url.PathEscape(name), nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) UpdatePrincipalRole(ctx context.Context, name string, req polarisUpdatePrincipalRoleRequest) (*polarisPrincipalRole, error) {
+	var out polarisPrincipalRole
+	if err := c.do(ctx, http.MethodPut, "/principal-roles/"+url.PathEscape(name), nil, req, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) DeletePrincipalRole(ctx context.Context, name string) error {
+	return c.do(ctx, http.MethodDelete, "/principal-roles/"+url.PathEscape(name), nil, nil, nil)
+}
+
+func (c *polarisManagementClient) ListPrincipalRoles(ctx context.Context) (*polarisPrincipalRoles, error) {
+	var out polarisPrincipalRoles
+	if err := c.do(ctx, http.MethodGet, "/principal-roles", nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// ─── Principal Role Assignments ───────────────────────────────────────────
+
+type polarisPrincipalRoleAssignment struct {
+	PrincipalRoleName string `json:"-"`
+}
+
+func (c *polarisManagementClient) AssignPrincipalRole(ctx context.Context, principalName string, roleName string) error {
+	body := map[string]any{
+		"principalRole": map[string]string{"name": roleName},
+	}
+
+	return c.do(ctx, http.MethodPut, "/principals/"+url.PathEscape(principalName)+"/principal-roles", nil, body, nil)
+}
+
+func (c *polarisManagementClient) ListPrincipalRoleAssignments(ctx context.Context, principalName string) (*polarisPrincipalRoles, error) {
+	var out polarisPrincipalRoles
+	if err := c.do(ctx, http.MethodGet, "/principals/"+url.PathEscape(principalName)+"/principal-roles", nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) RevokePrincipalRole(ctx context.Context, principalName string, roleName string) error {
+	return c.do(ctx, http.MethodDelete, "/principals/"+url.PathEscape(principalName)+"/principal-roles/"+url.PathEscape(roleName), nil, nil, nil)
+}
+
+// ─── Catalog Roles ────────────────────────────────────────────────────────
+
+type polarisCatalogRole struct {
+	Name                string            `json:"name"`
+	Properties          map[string]string `json:"properties,omitempty"`
+	EntityVersion       int64             `json:"entityVersion,omitempty"`
+	CreateTimestamp     int64             `json:"createTimestamp,omitempty"`
+	LastUpdateTimestamp int64             `json:"lastUpdateTimestamp,omitempty"`
+}
+
+type polarisCreateCatalogRoleRequest struct {
+	CatalogRole polarisCatalogRole `json:"catalogRole"`
+}
+
+type polarisUpdateCatalogRoleRequest struct {
+	CurrentEntityVersion int64             `json:"currentEntityVersion"`
+	Properties           map[string]string `json:"properties,omitempty"`
+}
+
+type polarisCatalogRoles struct {
+	Roles []polarisCatalogRole `json:"roles"`
+}
+
+func (c *polarisManagementClient) CreateCatalogRole(ctx context.Context, catalogName string, req polarisCreateCatalogRoleRequest) (*polarisCatalogRole, error) {
+	var out polarisCatalogRole
+	if err := c.do(ctx, http.MethodPost, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles", nil, req, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) GetCatalogRole(ctx context.Context, catalogName, roleName string) (*polarisCatalogRole, error) {
+	var out polarisCatalogRole
+	if err := c.do(ctx, http.MethodGet, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles/"+url.PathEscape(roleName), nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) UpdateCatalogRole(ctx context.Context, catalogName, roleName string, req polarisUpdateCatalogRoleRequest) (*polarisCatalogRole, error) {
+	var out polarisCatalogRole
+	if err := c.do(ctx, http.MethodPut, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles/"+url.PathEscape(roleName), nil, req, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) DeleteCatalogRole(ctx context.Context, catalogName, roleName string) error {
+	return c.do(ctx, http.MethodDelete, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles/"+url.PathEscape(roleName), nil, nil, nil)
+}
+
+func (c *polarisManagementClient) ListCatalogRoles(ctx context.Context, catalogName string) (*polarisCatalogRoles, error) {
+	var out polarisCatalogRoles
+	if err := c.do(ctx, http.MethodGet, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles", nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+// ─── Catalog Role Assignments (map catalog role to principal role) ────────
+
+func (c *polarisManagementClient) AssignCatalogRoleToPrincipalRole(ctx context.Context, principalRoleName, catalogName, catalogRoleName string) error {
+	body := map[string]any{
+		"catalogRole": map[string]string{"name": catalogRoleName},
+	}
+
+	return c.do(ctx, http.MethodPut, "/principal-roles/"+url.PathEscape(principalRoleName)+"/catalog-roles/"+url.PathEscape(catalogName), nil, body, nil)
+}
+
+func (c *polarisManagementClient) ListCatalogRoleAssignments(ctx context.Context, principalRoleName, catalogName string) (*polarisCatalogRoles, error) {
+	var out polarisCatalogRoles
+	if err := c.do(ctx, http.MethodGet, "/principal-roles/"+url.PathEscape(principalRoleName)+"/catalog-roles/"+url.PathEscape(catalogName), nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) RevokeCatalogRoleFromPrincipalRole(ctx context.Context, principalRoleName, catalogName, catalogRoleName string) error {
+	return c.do(ctx, http.MethodDelete, "/principal-roles/"+url.PathEscape(principalRoleName)+"/catalog-roles/"+url.PathEscape(catalogName)+"/"+url.PathEscape(catalogRoleName), nil, nil, nil)
+}
+
+// ─── Grants ───────────────────────────────────────────────────────────────
+
+type polarisGrantResourceBody struct {
+	Type      string   `json:"type"`
+	Privilege string   `json:"privilege"`
+	Namespace []string `json:"namespace,omitempty"`
+	TableName string   `json:"tableName,omitempty"`
+	ViewName  string   `json:"viewName,omitempty"`
+}
+
+type polarisAddGrantRequest struct {
+	Grant polarisGrantResourceBody `json:"grant"`
+}
+
+type polarisGrantResources struct {
+	Grants []polarisGrantResourceBody `json:"grants"`
+}
+
+func (c *polarisManagementClient) AddGrant(ctx context.Context, catalogName, catalogRoleName string, grant polarisGrantResourceBody) error {
+	body := polarisAddGrantRequest{Grant: grant}
+
+	return c.do(ctx, http.MethodPut, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles/"+url.PathEscape(catalogRoleName)+"/grants", nil, body, nil)
+}
+
+func (c *polarisManagementClient) ListGrants(ctx context.Context, catalogName, catalogRoleName string) (*polarisGrantResources, error) {
+	var out polarisGrantResources
+	if err := c.do(ctx, http.MethodGet, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles/"+url.PathEscape(catalogRoleName)+"/grants", nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) RevokeGrant(ctx context.Context, catalogName, catalogRoleName string, grant polarisGrantResourceBody, cascade bool) error {
+	q := url.Values{}
+	if cascade {
+		q.Set("cascade", "true")
+	}
+	body := polarisAddGrantRequest{Grant: grant}
+
+	return c.do(ctx, http.MethodPost, "/catalogs/"+url.PathEscape(catalogName)+"/catalog-roles/"+url.PathEscape(catalogRoleName)+"/grants", q, body, nil)
+}

--- a/internal/provider/polaris_management_client_test.go
+++ b/internal/provider/polaris_management_client_test.go
@@ -1,0 +1,493 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var ctx = context.Background()
+
+func newTestManagementServer(t *testing.T, mux *http.ServeMux) (*polarisManagementClient, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	client := &polarisManagementClient{
+		baseURL:    mustParseURL(srv.URL + "/api/management/v1"),
+		httpClient: srv.Client(),
+		token:      "test-token",
+	}
+
+	return client, srv
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
+// ─── Principal Role Tests ─────────────────────────────────────────────────
+
+func TestCreatePrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		var req polarisCreatePrincipalRoleRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "data_engineer", req.PrincipalRole.Name)
+		assert.True(t, req.PrincipalRole.Federated)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(polarisPrincipalRole{
+			Name:      "data_engineer",
+			Federated: true,
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	req := polarisCreatePrincipalRoleRequest{
+		PrincipalRole: polarisPrincipalRole{
+			Name:      "data_engineer",
+			Federated: true,
+		},
+	}
+	result, err := client.CreatePrincipalRole(ctx, req)
+	require.NoError(t, err)
+	assert.Equal(t, "data_engineer", result.Name)
+	assert.True(t, result.Federated)
+}
+
+func TestCreatePrincipalRole_403(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	_, err := client.CreatePrincipalRole(context.Background(), polarisCreatePrincipalRoleRequest{
+		PrincipalRole: polarisPrincipalRole{Name: "test"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestGetPrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/data_engineer", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisPrincipalRole{
+			Name:      "data_engineer",
+			Federated: false,
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.GetPrincipalRole(ctx, "data_engineer")
+	require.NoError(t, err)
+	assert.Equal(t, "data_engineer", result.Name)
+}
+
+func TestGetPrincipalRole_404(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/nonexistent", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	_, err := client.GetPrincipalRole(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.True(t, isPolarisNotFoundError(err))
+}
+
+func TestUpdatePrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/test-role", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		var req polarisUpdatePrincipalRoleRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, int64(5), req.CurrentEntityVersion)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisPrincipalRole{
+			Name:          "test-role",
+			EntityVersion: 6,
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.UpdatePrincipalRole(ctx, "test-role", polarisUpdatePrincipalRoleRequest{
+		CurrentEntityVersion: 5,
+		Properties:           map[string]string{"key": "val"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(6), result.EntityVersion)
+}
+
+func TestUpdatePrincipalRole_409(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/test-role", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			http.Error(w, "conflict", http.StatusConflict)
+		}
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	_, err := client.UpdatePrincipalRole(ctx, "test-role", polarisUpdatePrincipalRoleRequest{
+		CurrentEntityVersion: 5,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "409")
+}
+
+func TestDeletePrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/test-role", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.DeletePrincipalRole(ctx, "test-role")
+	require.NoError(t, err)
+}
+
+func TestDeletePrincipalRole_404(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/nonexistent", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.DeletePrincipalRole(ctx, "nonexistent")
+	require.Error(t, err)
+	assert.True(t, isPolarisNotFoundError(err))
+}
+
+func TestListPrincipalRoles(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisPrincipalRoles{
+			Roles: []polarisPrincipalRole{
+				{Name: "role1"},
+				{Name: "role2"},
+			},
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.ListPrincipalRoles(ctx)
+	require.NoError(t, err)
+	assert.Len(t, result.Roles, 2)
+	assert.Equal(t, "role1", result.Roles[0].Name)
+}
+
+// ─── Catalog Role Tests ───────────────────────────────────────────────────
+
+func TestCreateCatalogRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/test-cat/catalog-roles", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(polarisCatalogRole{Name: "test-role"})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.CreateCatalogRole(ctx, "test-cat", polarisCreateCatalogRoleRequest{
+		CatalogRole: polarisCatalogRole{Name: "test-role"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "test-role", result.Name)
+}
+
+func TestCreateCatalogRole_404(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/nonexistent/catalog-roles", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	_, err := client.CreateCatalogRole(ctx, "nonexistent", polarisCreateCatalogRoleRequest{
+		CatalogRole: polarisCatalogRole{Name: "test"},
+	})
+	require.Error(t, err)
+	assert.True(t, isPolarisNotFoundError(err))
+}
+
+func TestGetCatalogRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/test-cat/catalog-roles/test-role", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisCatalogRole{Name: "test-role", Properties: map[string]string{"k": "v"}})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.GetCatalogRole(ctx, "test-cat", "test-role")
+	require.NoError(t, err)
+	assert.Equal(t, "test-role", result.Name)
+	assert.Equal(t, "v", result.Properties["k"])
+}
+
+func TestDeleteCatalogRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/test-cat/catalog-roles/test-role", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.DeleteCatalogRole(ctx, "test-cat", "test-role")
+	require.NoError(t, err)
+}
+
+func TestListCatalogRoles(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/test-cat/catalog-roles", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisCatalogRoles{
+			Roles: []polarisCatalogRole{
+				{Name: "role1", Properties: map[string]string{"a": "b"}},
+			},
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.ListCatalogRoles(ctx, "test-cat")
+	require.NoError(t, err)
+	assert.Len(t, result.Roles, 1)
+	assert.Equal(t, "role1", result.Roles[0].Name)
+}
+
+// ─── Principal Role Assignment Tests ──────────────────────────────────────
+
+func TestAssignPrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principals/alice/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.AssignPrincipalRole(ctx, "alice", "data_engineer")
+	require.NoError(t, err)
+}
+
+func TestAssignPrincipalRole_404(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principals/nonexistent/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.AssignPrincipalRole(ctx, "nonexistent", "test-role")
+	require.Error(t, err)
+	assert.True(t, isPolarisNotFoundError(err))
+}
+
+func TestListPrincipalRoleAssignments(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principals/alice/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisPrincipalRoles{
+			Roles: []polarisPrincipalRole{
+				{Name: "data_engineer"},
+				{Name: "admin"},
+			},
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.ListPrincipalRoleAssignments(ctx, "alice")
+	require.NoError(t, err)
+	assert.Len(t, result.Roles, 2)
+}
+
+func TestRevokePrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principals/alice/principal-roles/data_engineer", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.RevokePrincipalRole(ctx, "alice", "data_engineer")
+	require.NoError(t, err)
+}
+
+// ─── Catalog Role Assignment Tests ────────────────────────────────────────
+
+func TestAssignCatalogRoleToPrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/data_engineer/catalog-roles/my_catalog", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.AssignCatalogRoleToPrincipalRole(ctx, "data_engineer", "my_catalog", "namespace_admin")
+	require.NoError(t, err)
+}
+
+func TestListCatalogRoleAssignments(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/data_engineer/catalog-roles/my_catalog", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisCatalogRoles{
+			Roles: []polarisCatalogRole{
+				{Name: "namespace_admin"},
+			},
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.ListCatalogRoleAssignments(ctx, "data_engineer", "my_catalog")
+	require.NoError(t, err)
+	assert.Len(t, result.Roles, 1)
+}
+
+func TestRevokeCatalogRoleFromPrincipalRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/principal-roles/data_engineer/catalog-roles/my_catalog/namespace_admin", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.RevokeCatalogRoleFromPrincipalRole(ctx, "data_engineer", "my_catalog", "namespace_admin")
+	require.NoError(t, err)
+}
+
+// ─── Grant Tests ──────────────────────────────────────────────────────────
+
+func TestAddGrant(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/my_catalog/catalog-roles/namespace_admin/grants", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		var req polarisAddGrantRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "namespace", req.Grant.Type)
+		assert.Equal(t, "NAMESPACE_LIST", req.Grant.Privilege)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.AddGrant(ctx, "my_catalog", "namespace_admin", polarisGrantResourceBody{
+		Type:      "namespace",
+		Privilege: "NAMESPACE_LIST",
+		Namespace: []string{"my_namespace"},
+	})
+	require.NoError(t, err)
+}
+
+func TestListGrants(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/my_catalog/catalog-roles/namespace_admin/grants", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(polarisGrantResources{
+			Grants: []polarisGrantResourceBody{
+				{Type: "namespace", Privilege: "NAMESPACE_LIST", Namespace: []string{"my_ns"}},
+			},
+		})
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	result, err := client.ListGrants(ctx, "my_catalog", "namespace_admin")
+	require.NoError(t, err)
+	assert.Len(t, result.Grants, 1)
+}
+
+func TestRevokeGrant(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/management/v1/catalogs/my_catalog/catalog-roles/namespace_admin/grants", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "true", r.URL.Query().Get("cascade"))
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	client, srv := newTestManagementServer(t, mux)
+	defer srv.Close()
+
+	err := client.RevokeGrant(ctx, "my_catalog", "namespace_admin", polarisGrantResourceBody{
+		Type:      "namespace",
+		Privilege: "NAMESPACE_LIST",
+		Namespace: []string{"my_ns"},
+	}, true)
+	require.NoError(t, err)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -235,6 +235,8 @@ func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 func (p *icebergProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewTableDataSource,
+		NewPolarisPrincipalRoleDataSource,
+		NewPolarisCatalogRoleDataSource,
 	}
 }
 
@@ -244,5 +246,10 @@ func (p *icebergProvider) Resources(_ context.Context) []func() resource.Resourc
 		NewNamespaceResource,
 		NewTableResource,
 		NewPolarisPrincipalResource,
+		NewPolarisPrincipalRoleResource,
+		NewPolarisPrincipalRoleAssignmentResource,
+		NewPolarisCatalogRoleResource,
+		NewPolarisCatalogRoleAssignmentResource,
+		NewPolarisGrantResource,
 	}
 }

--- a/internal/provider/provider_helpers.go
+++ b/internal/provider/provider_helpers.go
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// mapToStringMap converts a types.Map to map[string]string.
+func mapToStringMap(ctx context.Context, m types.Map) map[string]string {
+	if m.IsNull() || m.IsUnknown() {
+		return nil
+	}
+	var out map[string]string
+	diags := m.ElementsAs(ctx, &out, false)
+	if diags.HasError() {
+		return nil
+	}
+
+	return out
+}
+
+// requiresReplaceIfChanged returns a plan modifier that forces replacement
+// when a bool attribute changes.
+func requiresReplaceIfChanged() planmodifier.Bool {
+	return &requiresReplaceBoolModifier{}
+}
+
+type requiresReplaceBoolModifier struct{}
+
+func (m *requiresReplaceBoolModifier) Description(ctx context.Context) string {
+	return "If the value of this attribute changes, Terraform will destroy and recreate the resource."
+}
+
+func (m *requiresReplaceBoolModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m *requiresReplaceBoolModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if req.StateValue.IsNull() || req.ConfigValue.IsNull() {
+		return
+	}
+	if req.StateValue.ValueBool() != req.ConfigValue.ValueBool() {
+		resp.RequiresReplace = true
+	}
+}
+
+// requiresReplaceIfListChanged returns a plan modifier that forces replacement
+// when a list attribute changes.
+func requiresReplaceIfListChanged() planmodifier.List {
+	return &requiresReplaceListModifier{}
+}
+
+type requiresReplaceListModifier struct{}
+
+func (m *requiresReplaceListModifier) Description(ctx context.Context) string {
+	return "If the value of this attribute changes, Terraform will destroy and recreate the resource."
+}
+
+func (m *requiresReplaceListModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m *requiresReplaceListModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.StateValue.IsNull() || req.ConfigValue.IsNull() {
+		return
+	}
+	if !req.StateValue.Equal(req.ConfigValue) {
+		resp.RequiresReplace = true
+	}
+}
+
+// retryOnConflict calls fn; if it returns a 409-like error, calls retryFn once.
+// Used for optimistic locking retry.
+func retryOnConflict[T any](fn func() (T, error), retryFn func() (T, error)) (T, error) {
+	var zero T
+	result, err := fn()
+	if err != nil {
+		if isConflictError(err) {
+			result, err = retryFn()
+			if err != nil {
+				if isConflictError(err) {
+					return zero, fmt.Errorf("concurrent modification: %w", err)
+				}
+
+				return zero, err
+			}
+
+			return result, nil
+		}
+
+		return zero, err
+	}
+
+	return result, nil
+}
+
+func isConflictError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "status 409")
+}

--- a/internal/provider/resource_polaris_catalog_role.go
+++ b/internal/provider/resource_polaris_catalog_role.go
@@ -1,0 +1,316 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &polarisCatalogRoleResource{}
+	_ resource.ResourceWithImportState = &polarisCatalogRoleResource{}
+)
+
+func NewPolarisCatalogRoleResource() resource.Resource {
+	return &polarisCatalogRoleResource{}
+}
+
+type polarisCatalogRoleResource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisCatalogRoleResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	CatalogName types.String `tfsdk:"catalog_name"`
+	Name        types.String `tfsdk:"name"`
+	Properties  types.Map    `tfsdk:"properties"`
+}
+
+func (r *polarisCatalogRoleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_catalog_role"
+}
+
+func (r *polarisCatalogRoleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "A resource for managing Polaris catalog roles.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"catalog_name": schema.StringAttribute{
+				Description: "The catalog this role belongs to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the catalog role.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"properties": schema.MapAttribute{
+				Description: "Arbitrary metadata properties for the catalog role.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (r *polarisCatalogRoleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Expected *icebergProvider, got a different type.",
+		)
+
+		return
+	}
+	r.provider = provider
+}
+
+func (r *polarisCatalogRoleResource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if r.managementClient != nil {
+		return
+	}
+	if r.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := r.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	r.managementClient = client
+}
+
+func (r *polarisCatalogRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	props := mapToStringMap(ctx, data.Properties)
+
+	createReq := polarisCreateCatalogRoleRequest{
+		CatalogRole: polarisCatalogRole{
+			Name:       data.Name.ValueString(),
+			Properties: props,
+		},
+	}
+
+	tflog.Info(ctx, "Creating Polaris catalog role", map[string]any{
+		"catalog": data.CatalogName.ValueString(),
+		"name":    data.Name.ValueString(),
+	})
+
+	created, err := r.managementClient.CreateCatalogRole(ctx, data.CatalogName.ValueString(), createReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create catalog role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(data.CatalogName.ValueString() + "/" + created.Name)
+	data.Name = types.StringValue(created.Name)
+	if len(created.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, created.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisCatalogRoleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	role, err := r.managementClient.GetCatalogRole(ctx, data.CatalogName.ValueString(), data.Name.ValueString())
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read catalog role", err.Error())
+
+		return
+	}
+
+	data.Name = types.StringValue(role.Name)
+	if len(role.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, role.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisCatalogRoleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var plan, state polarisCatalogRoleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	catalogName := state.CatalogName.ValueString()
+	roleName := state.Name.ValueString()
+
+	current, err := r.managementClient.GetCatalogRole(ctx, catalogName, roleName)
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read catalog role for update", err.Error())
+
+		return
+	}
+
+	props := mapToStringMap(ctx, plan.Properties)
+
+	updateReq := polarisUpdateCatalogRoleRequest{
+		CurrentEntityVersion: current.EntityVersion,
+		Properties:           props,
+	}
+
+	updated, err := retryOnConflict(func() (*polarisCatalogRole, error) {
+		return r.managementClient.UpdateCatalogRole(ctx, catalogName, roleName, updateReq)
+	}, func() (*polarisCatalogRole, error) {
+		current, err := r.managementClient.GetCatalogRole(ctx, catalogName, roleName)
+		if err != nil {
+			return nil, err
+		}
+		updateReq.CurrentEntityVersion = current.EntityVersion
+
+		return r.managementClient.UpdateCatalogRole(ctx, catalogName, roleName, updateReq)
+	})
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to update catalog role", err.Error())
+
+		return
+	}
+
+	if len(updated.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, updated.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Properties = propsVal
+	} else {
+		state.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *polarisCatalogRoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Deleting Polaris catalog role", map[string]any{
+		"catalog": data.CatalogName.ValueString(),
+		"name":    data.Name.ValueString(),
+	})
+
+	err := r.managementClient.DeleteCatalogRole(ctx, data.CatalogName.ValueString(), data.Name.ValueString())
+	if err != nil && !isPolarisNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to delete catalog role", err.Error())
+	}
+}
+
+func (r *polarisCatalogRoleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Invalid import ID", "Expected format: {catalog_name}/{role_name}")
+
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("catalog_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+}

--- a/internal/provider/resource_polaris_catalog_role_assignment.go
+++ b/internal/provider/resource_polaris_catalog_role_assignment.go
@@ -1,0 +1,254 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &polarisCatalogRoleAssignmentResource{}
+	_ resource.ResourceWithImportState = &polarisCatalogRoleAssignmentResource{}
+)
+
+func NewPolarisCatalogRoleAssignmentResource() resource.Resource {
+	return &polarisCatalogRoleAssignmentResource{}
+}
+
+type polarisCatalogRoleAssignmentResource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisCatalogRoleAssignmentResourceModel struct {
+	ID                types.String `tfsdk:"id"`
+	PrincipalRoleName types.String `tfsdk:"principal_role_name"`
+	CatalogName       types.String `tfsdk:"catalog_name"`
+	CatalogRoleName   types.String `tfsdk:"catalog_role_name"`
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_catalog_role_assignment"
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Assigns a catalog role to a principal role.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"principal_role_name": schema.StringAttribute{
+				Description: "The principal role receiving the assignment.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"catalog_name": schema.StringAttribute{
+				Description: "The catalog containing the role to assign.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"catalog_role_name": schema.StringAttribute{
+				Description: "The catalog role to assign to the principal role.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Expected *icebergProvider, got a different type.",
+		)
+
+		return
+	}
+	r.provider = provider
+}
+
+func (r *polarisCatalogRoleAssignmentResource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if r.managementClient != nil {
+		return
+	}
+	if r.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := r.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	r.managementClient = client
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleAssignmentResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Assigning catalog role to principal role", map[string]any{
+		"principal_role": data.PrincipalRoleName.ValueString(),
+		"catalog":        data.CatalogName.ValueString(),
+		"catalog_role":   data.CatalogRoleName.ValueString(),
+	})
+
+	err := r.managementClient.AssignCatalogRoleToPrincipalRole(
+		ctx,
+		data.PrincipalRoleName.ValueString(),
+		data.CatalogName.ValueString(),
+		data.CatalogRoleName.ValueString(),
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to assign catalog role to principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(
+		data.PrincipalRoleName.ValueString() + "/" +
+			data.CatalogName.ValueString() + "/" +
+			data.CatalogRoleName.ValueString(),
+	)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleAssignmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	catalogRoles, err := r.managementClient.ListCatalogRoleAssignments(
+		ctx,
+		data.PrincipalRoleName.ValueString(),
+		data.CatalogName.ValueString(),
+	)
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to list catalog role assignments", err.Error())
+
+		return
+	}
+
+	found := false
+	for _, role := range catalogRoles.Roles {
+		if role.Name == data.CatalogRoleName.ValueString() {
+			found = true
+
+			break
+		}
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError("Update not supported", "Change attributes to force recreation.")
+}
+
+func (r *polarisCatalogRoleAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisCatalogRoleAssignmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Revoking catalog role from principal role", map[string]any{
+		"principal_role": data.PrincipalRoleName.ValueString(),
+		"catalog":        data.CatalogName.ValueString(),
+		"catalog_role":   data.CatalogRoleName.ValueString(),
+	})
+
+	err := r.managementClient.RevokeCatalogRoleFromPrincipalRole(
+		ctx,
+		data.PrincipalRoleName.ValueString(),
+		data.CatalogName.ValueString(),
+		data.CatalogRoleName.ValueString(),
+	)
+	if err != nil && !isPolarisNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to revoke catalog role from principal role", err.Error())
+	}
+}
+
+func (r *polarisCatalogRoleAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 3)
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError("Invalid import ID", "Expected format: {principal_role_name}/{catalog_name}/{catalog_role_name}")
+
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("principal_role_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("catalog_name"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("catalog_role_name"), parts[2])...)
+}

--- a/internal/provider/resource_polaris_catalog_role_test.go
+++ b/internal/provider/resource_polaris_catalog_role_test.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const testCatalogName = "test_catalog"
+
+func TestAccPolarisCatalogRole_Basic(t *testing.T) {
+	catalogURI := os.Getenv("POLARIS_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("POLARIS_CATALOG_URI not set, skipping real-cluster test")
+	}
+	managementURI := os.Getenv("POLARIS_MANAGEMENT_URI")
+	if managementURI == "" {
+		managementURI = catalogURI + "/api/management/v1"
+	}
+	token := os.Getenv("POLARIS_TOKEN")
+
+	providerCfg := testAccPolarisProviderConfigWithToken(catalogURI, managementURI, token)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + `
+resource "iceberg_polaris_catalog_role" "test" {
+  catalog_name = "` + testCatalogName + `"
+  name         = "test-catalog-role-acceptance"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_catalog_role.test", "name", "test-catalog-role-acceptance"),
+					resource.TestCheckResourceAttr("iceberg_polaris_catalog_role.test", "catalog_name", testCatalogName),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_polaris_grant.go
+++ b/internal/provider/resource_polaris_grant.go
@@ -1,0 +1,500 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &polarisGrantResource{}
+	_ resource.ResourceWithImportState = &polarisGrantResource{}
+)
+
+func NewPolarisGrantResource() resource.Resource {
+	return &polarisGrantResource{}
+}
+
+type polarisGrantResource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type grantSecurableKind string
+
+const (
+	grantKindCatalog   grantSecurableKind = "CATALOG"
+	grantKindNamespace grantSecurableKind = "NAMESPACE"
+	grantKindTable     grantSecurableKind = "TABLE"
+	grantKindView      grantSecurableKind = "VIEW"
+)
+
+type polarisGrantResourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	CatalogName     types.String `tfsdk:"catalog_name"`
+	CatalogRoleName types.String `tfsdk:"catalog_role_name"`
+	Privilege       types.String `tfsdk:"privilege"`
+	Catalog         types.String `tfsdk:"catalog"`
+	Namespace       types.List   `tfsdk:"namespace"`
+	Table           types.String `tfsdk:"table"`
+	View            types.String `tfsdk:"view"`
+	Cascade         types.Bool   `tfsdk:"cascade"`
+}
+
+// resolveSecurable returns the kind of securable resource this grant targets,
+// along with the parsed namespace parts and object name (for table/view).
+func (m *polarisGrantResourceModel) resolveSecurable(ctx context.Context) (grantSecurableKind, []string, string, error) {
+	ns := listToStringSlice(ctx, m.Namespace)
+
+	hasCatalog := !m.Catalog.IsNull() && !m.Catalog.IsUnknown() && m.Catalog.ValueString() != ""
+	hasNs := len(ns) > 0
+	hasTable := !m.Table.IsNull() && !m.Table.IsUnknown() && m.Table.ValueString() != ""
+	hasView := !m.View.IsNull() && !m.View.IsUnknown() && m.View.ValueString() != ""
+
+	set := 0
+	if hasCatalog {
+		set++
+	}
+	if hasNs && !hasTable && !hasView {
+		set++
+	}
+	if hasTable {
+		set++
+	}
+	if hasView {
+		set++
+	}
+
+	if set == 0 {
+		return "", nil, "", errors.New("one of catalog, namespace, table, or view must be set")
+	}
+	if set > 1 {
+		return "", nil, "", errors.New("catalog, namespace, table, and view are mutually exclusive")
+	}
+	if hasTable && !hasNs {
+		return "", nil, "", errors.New("table requires namespace to be set")
+	}
+	if hasView && !hasNs {
+		return "", nil, "", errors.New("view requires namespace to be set")
+	}
+
+	switch {
+	case hasCatalog:
+		return grantKindCatalog, nil, "", nil
+	case hasTable:
+		return grantKindTable, ns, m.Table.ValueString(), nil
+	case hasView:
+		return grantKindView, ns, m.View.ValueString(), nil
+	default:
+		return grantKindNamespace, ns, "", nil
+	}
+}
+
+func (r *polarisGrantResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_grant"
+}
+
+func (r *polarisGrantResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Grants a privilege on a securable object to a catalog role.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"catalog_name": schema.StringAttribute{
+				Description: "The catalog containing the role.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"catalog_role_name": schema.StringAttribute{
+				Description: "The catalog role receiving the grant.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"privilege": schema.StringAttribute{
+				Description: "The privilege to grant.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"catalog": schema.StringAttribute{
+				Description: "Grant on the whole catalog. Mutually exclusive with namespace/table/view.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"namespace": schema.ListAttribute{
+				Description: "Namespace to grant on (e.g. [\"ns1\", \"subns\"]). Required if table or view is set.",
+				Optional:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					requiresReplaceIfListChanged(),
+				},
+			},
+			"table": schema.StringAttribute{
+				Description: "Table name to grant on. Requires namespace.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"view": schema.StringAttribute{
+				Description: "View name to grant on. Requires namespace.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"cascade": schema.BoolAttribute{
+				Description: "Cascade revocation to subresources (only used on destroy).",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+		},
+	}
+}
+
+func (r *polarisGrantResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Expected *icebergProvider, got a different type.",
+		)
+
+		return
+	}
+	r.provider = provider
+}
+
+func (r *polarisGrantResource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if r.managementClient != nil {
+		return
+	}
+	if r.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := r.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	r.managementClient = client
+}
+
+func (r *polarisGrantResource) validateSecurableType(ctx context.Context, data *polarisGrantResourceModel) error {
+	_, _, _, err := data.resolveSecurable(ctx)
+
+	return err
+}
+
+func (r *polarisGrantResource) buildGrantResource(ctx context.Context, data *polarisGrantResourceModel) polarisGrantResourceBody {
+	var grant polarisGrantResourceBody
+
+	kind, ns, name, _ := data.resolveSecurable(ctx)
+	grant.Privilege = data.Privilege.ValueString()
+
+	switch kind {
+	case grantKindCatalog:
+		grant.Type = "catalog"
+	case grantKindTable:
+		grant.Type = "table"
+		grant.Namespace = ns
+		grant.TableName = name
+	case grantKindView:
+		grant.Type = "view"
+		grant.Namespace = ns
+		grant.ViewName = name
+	case grantKindNamespace:
+		grant.Type = "namespace"
+		grant.Namespace = ns
+	}
+
+	return grant
+}
+
+func (r *polarisGrantResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisGrantResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.validateSecurableType(ctx, &data); err != nil {
+		resp.Diagnostics.AddError("Invalid grant configuration", err.Error())
+
+		return
+	}
+
+	grant := r.buildGrantResource(ctx, &data)
+
+	tflog.Info(ctx, "Creating grant", map[string]any{
+		"catalog":   data.CatalogName.ValueString(),
+		"role":      data.CatalogRoleName.ValueString(),
+		"type":      grant.Type,
+		"privilege": grant.Privilege,
+	})
+
+	if err := r.managementClient.AddGrant(ctx, data.CatalogName.ValueString(), data.CatalogRoleName.ValueString(), grant); err != nil {
+		resp.Diagnostics.AddError("Failed to add grant", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(buildGrantID(ctx, &data))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisGrantResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisGrantResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	grants, err := r.managementClient.ListGrants(ctx, data.CatalogName.ValueString(), data.CatalogRoleName.ValueString())
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to list grants", err.Error())
+
+		return
+	}
+
+	if !findMatchingGrant(ctx, grants, &data) {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisGrantResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// No-op update: cascade is the only mutable attribute, and it's only
+	// consumed on Delete. Just return the plan state as-is.
+	var data polarisGrantResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisGrantResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisGrantResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	grant := r.buildGrantResource(ctx, &data)
+	cascade := data.Cascade.ValueBool()
+
+	tflog.Info(ctx, "Revoking grant", map[string]any{
+		"catalog":   data.CatalogName.ValueString(),
+		"role":      data.CatalogRoleName.ValueString(),
+		"type":      grant.Type,
+		"privilege": grant.Privilege,
+		"cascade":   cascade,
+	})
+
+	err := r.managementClient.RevokeGrant(ctx, data.CatalogName.ValueString(), data.CatalogRoleName.ValueString(), grant, cascade)
+	if err != nil && !isPolarisNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to revoke grant", err.Error())
+	}
+}
+
+func (r *polarisGrantResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Format: {catalog_name}/{catalog_role_name}/{securable_type}/{resource_path}/{privilege}
+	parts := strings.SplitN(req.ID, "/", 5)
+	if len(parts) != 5 {
+		resp.Diagnostics.AddError("Invalid import ID", "Expected format: {catalog}/{role}/{type}/{resource_path}/{privilege}")
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("catalog_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("catalog_role_name"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("privilege"), parts[4])...)
+
+	securableType := parts[2]
+	resourcePath := parts[3]
+
+	switch securableType {
+	case "CATALOG":
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("catalog"), parts[0])...)
+	case "NAMESPACE":
+		nsParts := strings.Split(resourcePath, ".")
+		nsList, diags := types.ListValueFrom(ctx, types.StringType, nsParts)
+		resp.Diagnostics.Append(diags...)
+		if !diags.HasError() {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), nsList)...)
+		}
+	case "TABLE":
+		parts := strings.SplitN(resourcePath, ".", 2)
+		if len(parts) == 2 {
+			nsParts := strings.Split(parts[0], ".")
+			nsList, diags := types.ListValueFrom(ctx, types.StringType, nsParts)
+			resp.Diagnostics.Append(diags...)
+			if !diags.HasError() {
+				resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), nsList)...)
+			}
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("table"), parts[1])...)
+		}
+	case "VIEW":
+		vParts := strings.SplitN(resourcePath, ".", 2)
+		if len(vParts) == 2 {
+			nsParts := strings.Split(vParts[0], ".")
+			nsList, diags := types.ListValueFrom(ctx, types.StringType, nsParts)
+			resp.Diagnostics.Append(diags...)
+			if !diags.HasError() {
+				resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("namespace"), nsList)...)
+			}
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("view"), vParts[1])...)
+		}
+	default:
+		resp.Diagnostics.AddError("Invalid securable type in import ID", "Expected CATALOG, NAMESPACE, TABLE, or VIEW")
+	}
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+func buildGrantID(ctx context.Context, data *polarisGrantResourceModel) string {
+	catalogName := data.CatalogName.ValueString()
+	roleName := data.CatalogRoleName.ValueString()
+	privilege := data.Privilege.ValueString()
+
+	kind, ns, name, _ := data.resolveSecurable(ctx)
+
+	securableType := string(kind)
+	resourcePath := "null"
+
+	switch kind {
+	case grantKindTable:
+		resourcePath = strings.Join(ns, ".") + "." + name
+	case grantKindView:
+		resourcePath = strings.Join(ns, ".") + "." + name
+	case grantKindNamespace:
+		resourcePath = strings.Join(ns, ".")
+	}
+
+	return fmt.Sprintf("%s/%s/%s/%s/%s", catalogName, roleName, securableType, resourcePath, privilege)
+}
+
+func findMatchingGrant(ctx context.Context, grants *polarisGrantResources, data *polarisGrantResourceModel) bool {
+	privilege := data.Privilege.ValueString()
+	kind, ns, name, _ := data.resolveSecurable(ctx)
+
+	for _, g := range grants.Grants {
+		if g.Privilege != privilege {
+			continue
+		}
+
+		switch kind {
+		case grantKindCatalog:
+			if g.Type == "catalog" {
+				return true
+			}
+		case grantKindTable:
+			if g.Type == "table" && g.TableName == name {
+				return true
+			}
+		case grantKindView:
+			if g.Type == "view" && g.ViewName == name {
+				return true
+			}
+		case grantKindNamespace:
+			if g.Type == "namespace" && stringSlicesEqual(g.Namespace, ns) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func listToStringSlice(ctx context.Context, l types.List) []string {
+	if l.IsNull() || l.IsUnknown() {
+		return nil
+	}
+	var out []string
+	_ = l.ElementsAs(ctx, &out, false)
+
+	return out
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/provider/resource_polaris_grant_test.go
+++ b/internal/provider/resource_polaris_grant_test.go
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const testGrantCatalogName = "test_grant_catalog"
+
+func TestAccPolarisGrantCatalog(t *testing.T) {
+	catalogURI := os.Getenv("POLARIS_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("POLARIS_CATALOG_URI not set, skipping real-cluster test")
+	}
+	managementURI := os.Getenv("POLARIS_MANAGEMENT_URI")
+	if managementURI == "" {
+		managementURI = catalogURI + "/api/management/v1"
+	}
+	token := os.Getenv("POLARIS_TOKEN")
+
+	providerCfg := testAccPolarisProviderConfigWithToken(catalogURI, managementURI, token)
+
+	roleName := "test-grant-catalog-role"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + fmt.Sprintf(`
+resource "iceberg_polaris_catalog_role" "test" {
+  catalog_name = "%s"
+  name         = "%s"
+}
+
+resource "iceberg_polaris_grant" "test" {
+  catalog_name      = iceberg_polaris_catalog_role.test.catalog_name
+  catalog_role_name = iceberg_polaris_catalog_role.test.name
+  privilege         = "TABLE_LIST"
+  catalog           = iceberg_polaris_catalog_role.test.catalog_name
+}
+`, testGrantCatalogName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_grant.test", "privilege", "TABLE_LIST"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_polaris_principal.go
+++ b/internal/provider/resource_polaris_principal.go
@@ -111,6 +111,8 @@ func (r *polarisPrincipalResource) Configure(_ context.Context, req resource.Con
 			"Unexpected Resource Configure Type",
 			"Expected *icebergProvider, got a different type: %T. Please report this issue to the provider developers.",
 		)
+
+		return
 	}
 	r.provider = provider
 }
@@ -234,6 +236,12 @@ func (r *polarisPrincipalResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	// Credential rotation flag is not returned by the API on GET.
+	// Preserve from state if available, otherwise default to false.
+	if data.CredentialRotationRequired.IsNull() || data.CredentialRotationRequired.IsUnknown() {
+		data.CredentialRotationRequired = types.BoolValue(false)
+	}
+
 	// Update properties; credentials are not returned on GET so keep from state.
 	if len(principal.Properties) > 0 {
 		propsVal, diags := types.MapValueFrom(ctx, types.StringType, principal.Properties)
@@ -323,6 +331,13 @@ func (r *polarisPrincipalResource) Update(ctx context.Context, req resource.Upda
 	} else {
 		state.Properties = types.MapNull(types.StringType)
 	}
+
+	// Credential rotation flag not returned by API on update — preserve from plan
+	val := false
+	if !plan.CredentialRotationRequired.IsNull() && !plan.CredentialRotationRequired.IsUnknown() {
+		val = plan.CredentialRotationRequired.ValueBool()
+	}
+	state.CredentialRotationRequired = types.BoolValue(val)
 
 	// Polaris doesn't return credentials on update, and setting the secret requires
 	// a dedicated resetCredentials call after create. Preserve everything from state.

--- a/internal/provider/resource_polaris_principal_role.go
+++ b/internal/provider/resource_polaris_principal_role.go
@@ -1,0 +1,307 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &polarisPrincipalRoleResource{}
+	_ resource.ResourceWithImportState = &polarisPrincipalRoleResource{}
+)
+
+func NewPolarisPrincipalRoleResource() resource.Resource {
+	return &polarisPrincipalRoleResource{}
+}
+
+type polarisPrincipalRoleResource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisPrincipalRoleResourceModel struct {
+	ID         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Federated  types.Bool   `tfsdk:"federated"`
+	Properties types.Map    `tfsdk:"properties"`
+}
+
+func (r *polarisPrincipalRoleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_principal_role"
+}
+
+func (r *polarisPrincipalRoleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "A resource for managing Polaris principal roles.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the principal role.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"federated": schema.BoolAttribute{
+				Description: "Whether the role is managed by an external identity provider. Immutable after creation.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					requiresReplaceIfChanged(),
+				},
+			},
+			"properties": schema.MapAttribute{
+				Description: "Arbitrary metadata properties for the principal role.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (r *polarisPrincipalRoleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Expected *icebergProvider, got a different type. Please report this issue to the provider developers.",
+		)
+
+		return
+	}
+	r.provider = provider
+}
+
+func (r *polarisPrincipalRoleResource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if r.managementClient != nil {
+		return
+	}
+	if r.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := r.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	r.managementClient = client
+}
+
+func (r *polarisPrincipalRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	props := mapToStringMap(ctx, data.Properties)
+
+	createReq := polarisCreatePrincipalRoleRequest{
+		PrincipalRole: polarisPrincipalRole{
+			Name:       data.Name.ValueString(),
+			Federated:  data.Federated.ValueBool(),
+			Properties: props,
+		},
+	}
+
+	tflog.Info(ctx, "Creating Polaris principal role", map[string]any{"name": data.Name.ValueString()})
+
+	created, err := r.managementClient.CreatePrincipalRole(ctx, createReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(created.Name)
+	data.Name = types.StringValue(created.Name)
+	data.Federated = types.BoolValue(created.Federated)
+	if len(created.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, created.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisPrincipalRoleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	role, err := r.managementClient.GetPrincipalRole(ctx, data.Name.ValueString())
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(role.Name)
+	data.Name = types.StringValue(role.Name)
+	data.Federated = types.BoolValue(role.Federated)
+	if len(role.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, role.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisPrincipalRoleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var plan, state polarisPrincipalRoleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := state.Name.ValueString()
+
+	current, err := r.managementClient.GetPrincipalRole(ctx, name)
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read principal role for update", err.Error())
+
+		return
+	}
+
+	props := mapToStringMap(ctx, plan.Properties)
+
+	updateReq := polarisUpdatePrincipalRoleRequest{
+		CurrentEntityVersion: current.EntityVersion,
+		Properties:           props,
+	}
+
+	updated, err := retryOnConflict(func() (*polarisPrincipalRole, error) {
+		return r.managementClient.UpdatePrincipalRole(ctx, name, updateReq)
+	}, func() (*polarisPrincipalRole, error) {
+		current, err := r.managementClient.GetPrincipalRole(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		updateReq.CurrentEntityVersion = current.EntityVersion
+
+		return r.managementClient.UpdatePrincipalRole(ctx, name, updateReq)
+	})
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to update principal role", err.Error())
+
+		return
+	}
+
+	state.Federated = types.BoolValue(updated.Federated)
+	if len(updated.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, updated.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Properties = propsVal
+	} else {
+		state.Properties = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *polarisPrincipalRoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Deleting Polaris principal role", map[string]any{"name": data.Name.ValueString()})
+
+	err := r.managementClient.DeletePrincipalRole(ctx, data.Name.ValueString())
+	if err != nil && !isPolarisNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to delete principal role", err.Error())
+	}
+}
+
+func (r *polarisPrincipalRoleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
+}

--- a/internal/provider/resource_polaris_principal_role_assignment.go
+++ b/internal/provider/resource_polaris_principal_role_assignment.go
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &polarisPrincipalRoleAssignmentResource{}
+	_ resource.ResourceWithImportState = &polarisPrincipalRoleAssignmentResource{}
+)
+
+func NewPolarisPrincipalRoleAssignmentResource() resource.Resource {
+	return &polarisPrincipalRoleAssignmentResource{}
+}
+
+type polarisPrincipalRoleAssignmentResource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisPrincipalRoleAssignmentResourceModel struct {
+	ID                types.String `tfsdk:"id"`
+	PrincipalName     types.String `tfsdk:"principal_name"`
+	PrincipalRoleName types.String `tfsdk:"principal_role_name"`
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_principal_role_assignment"
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Assigns a principal role to a Polaris principal.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"principal_name": schema.StringAttribute{
+				Description: "The name of the principal to assign the role to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"principal_role_name": schema.StringAttribute{
+				Description: "The name of the principal role to assign.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Expected *icebergProvider, got a different type.",
+		)
+
+		return
+	}
+	r.provider = provider
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if r.managementClient != nil {
+		return
+	}
+	if r.provider == nil {
+		diags.AddError("Provider not configured", "The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := r.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	r.managementClient = client
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleAssignmentResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Assigning principal role", map[string]any{
+		"principal": data.PrincipalName.ValueString(),
+		"role":      data.PrincipalRoleName.ValueString(),
+	})
+
+	err := r.managementClient.AssignPrincipalRole(ctx, data.PrincipalName.ValueString(), data.PrincipalRoleName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to assign principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(data.PrincipalName.ValueString() + "/" + data.PrincipalRoleName.ValueString())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleAssignmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	assignments, err := r.managementClient.ListPrincipalRoleAssignments(ctx, data.PrincipalName.ValueString())
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to list principal role assignments", err.Error())
+
+		return
+	}
+
+	found := false
+	for _, role := range assignments.Roles {
+		if role.Name == data.PrincipalRoleName.ValueString() {
+			found = true
+
+			break
+		}
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// No Update — attribute changes trigger destroy + recreate via RequiresReplace.
+	// This should never be called, but handle gracefully.
+	resp.Diagnostics.AddError("Update not supported", "Change principal_name or principal_role_name to force recreation.")
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleAssignmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Revoking principal role", map[string]any{
+		"principal": data.PrincipalName.ValueString(),
+		"role":      data.PrincipalRoleName.ValueString(),
+	})
+
+	err := r.managementClient.RevokePrincipalRole(ctx, data.PrincipalName.ValueString(), data.PrincipalRoleName.ValueString())
+	if err != nil && !isPolarisNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to revoke principal role", err.Error())
+	}
+}
+
+func (r *polarisPrincipalRoleAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Invalid import ID", "Expected format: {principal_name}/{role_name}")
+
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("principal_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("principal_role_name"), parts[1])...)
+}

--- a/internal/provider/resource_polaris_principal_role_test.go
+++ b/internal/provider/resource_polaris_principal_role_test.go
@@ -1,0 +1,261 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func providerConfigWithManagementURI(srvAddr string) string {
+	return fmt.Sprintf(`
+provider "iceberg" {
+  type        = "polaris"
+  catalog_uri = "%s"
+
+  polaris_settings {
+    management_uri = "%s/api/management/v1"
+  }
+}
+`, srvAddr, srvAddr)
+}
+
+func newPolarisPrincipalRoleTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	roles := make(map[string]polarisPrincipalRole)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/management/v1/principal-roles", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var req polarisCreatePrincipalRoleRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+			name := req.PrincipalRole.Name
+			if name == "" {
+				http.Error(w, "missing name", http.StatusBadRequest)
+
+				return
+			}
+			if _, exists := roles[name]; exists {
+				http.Error(w, "already exists", http.StatusConflict)
+
+				return
+			}
+			role := polarisPrincipalRole{
+				Name:       name,
+				Federated:  req.PrincipalRole.Federated,
+				Properties: req.PrincipalRole.Properties,
+			}
+			roles[name] = role
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(role)
+
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	mux.HandleFunc("/api/management/v1/principal-roles/", func(w http.ResponseWriter, r *http.Request) {
+		name := extractLastPathSegment(r.URL.Path)
+
+		switch r.Method {
+		case http.MethodGet:
+			role, exists := roles[name]
+			if !exists {
+				http.Error(w, "not found", http.StatusNotFound)
+
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(role)
+
+		case http.MethodPut:
+			var req polarisUpdatePrincipalRoleRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+			role, exists := roles[name]
+			if !exists {
+				http.Error(w, "not found", http.StatusNotFound)
+
+				return
+			}
+			if req.Properties != nil {
+				role.Properties = req.Properties
+			}
+			role.EntityVersion++
+			roles[name] = role
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(role)
+
+		case http.MethodDelete:
+			delete(roles, name)
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func extractLastPathSegment(path string) string {
+	parts := splitPath(path)
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+
+	return ""
+}
+
+func splitPath(path string) []string {
+	var parts []string
+	current := ""
+	for _, c := range path {
+		if c == '/' {
+			if current != "" {
+				parts = append(parts, current)
+				current = ""
+			}
+		} else {
+			current += string(c)
+		}
+	}
+	if current != "" {
+		parts = append(parts, current)
+	}
+
+	return parts
+}
+
+func TestPrincipalRoleResource_Create(t *testing.T) {
+	srv := newPolarisPrincipalRoleTestServer(t)
+	defer srv.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfigWithManagementURI(srv.URL) + `
+resource "iceberg_polaris_principal_role" "test" {
+  name = "test-role"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "name", "test-role"),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "federated", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestPrincipalRoleResource_CreateWithProperties(t *testing.T) {
+	srv := newPolarisPrincipalRoleTestServer(t)
+	defer srv.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfigWithManagementURI(srv.URL) + `
+resource "iceberg_polaris_principal_role" "test" {
+  name = "test-role-props"
+  properties = {
+    team = "platform"
+    env  = "prod"
+  }
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "name", "test-role-props"),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.team", "platform"),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.env", "prod"),
+				),
+			},
+		},
+	})
+}
+
+func TestPrincipalRoleResource_Update(t *testing.T) {
+	srv := newPolarisPrincipalRoleTestServer(t)
+	defer srv.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfigWithManagementURI(srv.URL) + `
+resource "iceberg_polaris_principal_role" "test" {
+  name = "test-role-update"
+  properties = {
+    version = "1"
+  }
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.version", "1"),
+				),
+			},
+			{
+				Config: providerConfigWithManagementURI(srv.URL) + `
+resource "iceberg_polaris_principal_role" "test" {
+  name = "test-role-update"
+  properties = {
+    version = "2"
+  }
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.version", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPolarisPrincipalRole_Basic runs against a real Polaris deployment
+func TestAccPolarisPrincipalRole_Basic(t *testing.T) {
+	catalogURI := os.Getenv("POLARIS_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("POLARIS_CATALOG_URI not set, skipping real-cluster test")
+	}
+	managementURI := os.Getenv("POLARIS_MANAGEMENT_URI")
+	if managementURI == "" {
+		managementURI = catalogURI + "/api/management/v1"
+	}
+	token := os.Getenv("POLARIS_TOKEN")
+
+	providerCfg := testAccPolarisProviderConfigWithToken(catalogURI, managementURI, token)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + `
+resource "iceberg_polaris_principal_role" "test" {
+  name = "test-role-acceptance"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "name", "test-role-acceptance"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Implements RBAC resources and data sources for the [Polaris Management API](https://raw.githubusercontent.com/apache/polaris/refs/heads/main/spec/polaris-management-service.yml).

Resources:
- `iceberg_polaris_principal_role`
- `iceberg_polaris_principal_role_assignment`
- `iceberg_polaris_catalog_role`
- `iceberg_polaris_catalog_role_assignment`
- `iceberg_polaris_grant`

Data Sources:
- `iceberg_polaris_principal_role`
- `iceberg_polaris_catalog_role`

Example:

```hcl
resource "iceberg_polaris_catalog_role" "reader" {
  catalog_name = "my_catalog"
  name         = "catalog_reader"
}

resource "iceberg_polaris_grant" "ns_read" {
  catalog_name      = iceberg_polaris_catalog_role.reader.catalog_name
  catalog_role_name = iceberg_polaris_catalog_role.reader.name
  privilege         = "TABLE_LIST"
  namespace         = ["my_schema"]
}
```

Also fixes a missing `return` after type assertion failure in `resource_polaris_principal.go`'s Configure method.

I realise that [this existing PR](https://github.com/apache/terraform-provider-iceberg/pull/31) implements one of the resources this one does, but considering it's been dead for nearly 2 months I thought it'd be fine to include in mine rather than wait until it's merged. Happy to remove my version and wait for it first though.